### PR TITLE
Session Issues Fix

### DIFF
--- a/Class/Attribute.cs
+++ b/Class/Attribute.cs
@@ -96,6 +96,9 @@ namespace Hi3Helper.Http
                     .GetResult();
 
             }
+
+            public bool IsNeedRecalculateSize = true;
+            public bool IsMultisession = false;
             public Stream OutStream { get; private set; }
             public HttpResponseMessage RemoteResponse { get; set; }
             public HttpRequestMessage RemoteRequest { get; set; }

--- a/Class/Exception.cs
+++ b/Class/Exception.cs
@@ -5,43 +5,36 @@ namespace Hi3Helper.Http
     [Serializable]
     public class HttpHelperSessionNotReady : Exception
     {
-        public HttpHelperSessionNotReady() { }
         public HttpHelperSessionNotReady(string message) : base(message) { }
     }
 
     public class HttpHelperAllowedSessionsMaxed : Exception
     {
-        public HttpHelperAllowedSessionsMaxed() { }
         public HttpHelperAllowedSessionsMaxed(string message) : base(message) { }
     }
 
-    public class HttpHelperSessionChunkOversize : Exception
+    public class HttpHelperSessionHTTPError416 : Exception
     {
-        public HttpHelperSessionChunkOversize() { }
-        public HttpHelperSessionChunkOversize(string message) : base(message) { }
-    }
-
-    public class HttpHelperResponseNoSatisfiable : Exception
-    {
-        public HttpHelperResponseNoSatisfiable() { }
-        public HttpHelperResponseNoSatisfiable(string message) : base(message) { }
+        public HttpHelperSessionHTTPError416(string message) : base(message) { }
     }
 
     public class HttpHelperSessionMetadataNotExist : Exception
     {
-        public HttpHelperSessionMetadataNotExist() { }
         public HttpHelperSessionMetadataNotExist(string message) : base(message) { }
     }
 
     public class HttpHelperSessionMetadataInvalid : Exception
     {
-        public HttpHelperSessionMetadataInvalid() { }
         public HttpHelperSessionMetadataInvalid(string message) : base(message) { }
     }
 
     public class HttpHelperSessionFileExist : Exception
     {
-        public HttpHelperSessionFileExist() { }
         public HttpHelperSessionFileExist(string message) : base(message) { }
+    }
+
+    public class HttpHelperUnhandledError : Exception
+    {
+        public HttpHelperUnhandledError(string message, Exception ex) : base(message, ex) { }
     }
 }

--- a/Class/Merge.cs
+++ b/Class/Merge.cs
@@ -7,7 +7,7 @@ namespace Hi3Helper.Http
 {
     public partial class Http
     {
-        public async Task MergeMultisession(string OutPath, byte Sessions, CancellationToken Token)
+        public async Task MergeMultisession(string OutPath, byte Sessions = 4, CancellationToken Token = new CancellationToken())
         {
             int Read;
             byte[] Buffer = new byte[4 << 17];
@@ -61,18 +61,18 @@ namespace Hi3Helper.Http
             }
             catch (TaskCanceledException)
             {
-                Console.WriteLine($"Merging has been cancelled!");
                 this.SessionState = MultisessionState.CancelledMerging;
+                Console.WriteLine($"Merging has been cancelled!");
             }
             catch (OperationCanceledException)
             {
-                Console.WriteLine($"Merging has been cancelled!");
                 this.SessionState = MultisessionState.CancelledMerging;
+                Console.WriteLine($"Merging has been cancelled!");
             }
             catch (Exception ex)
             {
                 this.SessionState = MultisessionState.FailedMerging;
-                throw new Exception($"Unhandled exception while merging!\r\n{ex}", ex);
+                throw new HttpHelperUnhandledError($"Unhandled exception while merging has occured!\r\n{ex}", ex);
             }
         }
 

--- a/Http.cs
+++ b/Http.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -34,9 +35,7 @@ namespace Hi3Helper.Http
         {
             ResetAttributes();
             SessionAttribute Session = new SessionAttribute(URL, OutPath, null, Token, Start, End);
-            Task SessionTask = StartRetryableTask(Session);
-
-            await SessionTask;
+            await TryAwaitOrDisposeStreamWhileFail(StartRetryableTask(Session), Session);
         }
 
         public async void DownloadNoTask(string URL, string OutPath,
@@ -48,9 +47,7 @@ namespace Hi3Helper.Http
         {
             ResetAttributes();
             SessionAttribute Session = new SessionAttribute(URL, null, OutStream, Token, Start, End);
-            Task SessionTask = StartRetryableTask(Session);
-
-            await SessionTask;
+            await TryAwaitOrDisposeStreamWhileFail(StartRetryableTask(Session), Session);
         }
 
         public async void DownloadStreamNoTask(string URL, Stream OutStream, CancellationToken Token = new CancellationToken(),


### PR DESCRIPTION
Based on what we have received from other project (such as [**BetterHi3Launcher**](https://github.com/BuIlDaLiBlE/BetterHI3Launcher) and [**Collapse**](https://github.com/neon-nyan/CollapseLauncher)), we need to change some codes to fix some issues that I've received.

This Pull-Request bring some changes and fix, such as:
- Fix download progress never reach 100% perfectly (only near 99-ish%)
- Fix the download to go beyond 100% while retrying happened
- Add default argument on ``MergeMultisession()``
- Simplify some repeated code
- Now ``HttpHelperSessionHTTPError416`` exception will be called whether the offset range is invalid or the file has been completely downloaded.
- Fix the session offset on the single-session download to possibly overflowed.
- Fix some state on Multi-session download never get updated